### PR TITLE
fix: use Azure APT mirror, remove unreachable PPAs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,14 @@ FROM ghcr.io/actions/actions-runner:2.334.0
 
 USER root
 
+RUN rm -f /etc/apt/sources.list.d/*git-core*.list \
+    /etc/apt/sources.list.d/*ppa*.list \
+    /etc/apt/sources.list.d/*launchpad*.list \
+    /etc/apt/sources.list.d/*packagecloud*.list
+
+RUN sed -i 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list && \
+    sed -i 's|http://security.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list
+
 RUN apt update \
     && apt install -y curl \
     && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg \


### PR DESCRIPTION
## Summary
- Remove `ppa:git-core/ppa` and `ppa:git-lfs` PPAs inherited from base image — they fail with `Connection refused` on `ppa.launchpadcontent.net`
- Switch `archive.ubuntu.com` and `security.ubuntu.com` → `azure.archive.ubuntu.com` for reliable connectivity from GitHub Actions runners

## Why
Base image `ghcr.io/actions/actions-runner:2.334.0` pre-configures PPAs that point at `ppa.launchpadcontent.net`, which is currently unreachable. Every `apt-get update` fails hard on `Connection refused`, blocking the entire build.

## Changes
- Added `rm -f` to remove PPA `.list` files from `/etc/apt/sources.list.d/` before any `apt update`
- Added `sed` to replace Ubuntu archive URLs with Azure mirror