### PR TITLE
fix: handle DEB822 .sources files for APT mirror and PPA removal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,15 @@ FROM ghcr.io/actions/actions-runner:2.334.0
 
 USER root
 
-RUN rm -f /etc/apt/sources.list.d/*git-core*.list \
-    /etc/apt/sources.list.d/*ppa*.list \
-    /etc/apt/sources.list.d/*launchpad*.list \
-    /etc/apt/sources.list.d/*packagecloud*.list
+RUN rm -f /etc/apt/sources.list.d/*git-core* \
+    /etc/apt/sources.list.d/*ppa* \
+    /etc/apt/sources.list.d/*launchpad* \
+    /etc/apt/sources.list.d/*packagecloud*
 
-RUN sed -i 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list && \
-    sed -i 's|http://security.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list
+RUN sed -i 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
+        /etc/apt/sources.list /etc/apt/sources.list.d/*.sources 2>/dev/null || true && \
+    sed -i 's|http://security.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' \
+        /etc/apt/sources.list /etc/apt/sources.list.d/*.sources 2>/dev/null || true
 
 RUN apt update \
     && apt install -y curl \


### PR DESCRIPTION
## Summary
- Fix PPA removal and APT mirror replacement to also target DEB822 `.sources` files (Ubuntu Noble 24.04 format)
- The previous fix (PR #39) only targeted `.list` files, so PPAs and archive URLs in `.sources` files were not being modified

## Why
Ubuntu Noble (24.04) switched from the legacy `.list` format to DEB822 `.sources` files. The base image stores its source configurations in `/etc/apt/sources.list.d/*.sources`, which were not matched by the previous `rm -f *.list` glob or `sed` on `/etc/apt/sources.list`.

## Changes
- Removed `.list` extension from `rm -f` globs → now matches both `*.list` and `*.sources`
- Added `/etc/apt/sources.list.d/*.sources` to `sed` commands → replaces mirror URLs in DEB822 format