### PR TITLE
feat: install Node.js LTS via NodeSource for Playwright deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,14 @@ RUN curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor |
     && apt install -y azure-cli \
     && rm -rf /var/lib/apt/lists/*
 
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+    | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x $(lsb_release -cs) main" \
+    | tee /etc/apt/sources.list.d/nodesource.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN npx -y playwright-core@1.59.1 install-deps chromium
 
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary
- Install Node.js 22.x LTS via NodeSource before running `npx playwright-core install-deps`

## Why
The `ghcr.io/actions/actions-runner:2.334.0` base image does not include Node.js/npx. The Playwright OS deps step (`npx -y playwright-core@1.59.1 install-deps chromium`) fails with `npx: not found` (exit code 127).

Unlike `gitea/runner-images:ubuntu-latest` (used in act-runner), the actions-runner image doesn't have Node.js pre-installed.

## Changes
- Added NodeSource Node.js 22.x LTS installation step before the Playwright npx command