### PR TITLE
chore: upgrade playwright to 1.60.0 to fix hang on node 24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
     apt-get install -y --no-install-recommends nodejs && \
     rm -rf /var/lib/apt/lists/*
 
-RUN npx -y playwright-core@1.59.1 install-deps chromium
+RUN npx -y playwright-core@1.60.0 install-deps chromium
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl git-lfs age ca-certificates zip \


### PR DESCRIPTION
Upgrades playwright-core from 1.59.1 to 1.60.0 to resolve a known hang during zip extraction on Node.js 24.16.0.